### PR TITLE
Show custom IO redirects in command string

### DIFF
--- a/psh/process.py
+++ b/psh/process.py
@@ -1164,6 +1164,16 @@ class Process:
 
                 command += arg
 
+        if self.__stdout_target is STDERR:
+            command += " >&2"
+        elif isinstance(self.__stdout_target, File):
+            command += " > {0}".format(self.__stdout_target.path)
+
+        if self.__stderr_target is STDOUT:
+            command += " 2>&1"
+        elif isinstance(self.__stderr_target, File):
+            command += " 2> {0}".format(self.__stderr_target.path)
+
         return command
 
     def __wait_pid_thread(self, fork_lock, termination_fd):

--- a/tests/test_io_redirection.py
+++ b/tests/test_io_redirection.py
@@ -38,6 +38,10 @@ def test_command_with_redirection(test):
     assert str(process) == "echo test > /dev/null 2> /dev/null"
     assert bytes(process) == psys.b(str(process))
 
+    process = sh.echo("test", _stdout=File("/\rtmp\t/test.\rpath"))
+    assert str(process) == "echo test > '/\\rtmp\\t/test.\\rpath'"
+    assert bytes(process) == psys.b(str(process))
+
 def test_disabling_stdin_redirection(test, capfd):
     """Tests disabling stdin redirection."""
 

--- a/tests/test_io_redirection.py
+++ b/tests/test_io_redirection.py
@@ -15,6 +15,29 @@ import test
 test.init(globals())
 
 
+def test_command_with_redirection(test):
+    """Tests command arguments representation."""
+
+    process = sh.echo("test", _stdout=STDERR)
+    assert str(process) == "echo test >&2"
+    assert bytes(process) == psys.b(str(process))
+
+    process = sh.echo("test", _stdout=File("/tmp/test.path"))
+    assert str(process) == "echo test > /tmp/test.path"
+    assert bytes(process) == psys.b(str(process))
+
+    process = sh.echo("test", _stderr=File("/tmp/test.path"))
+    assert str(process) == "echo test 2> /tmp/test.path"
+    assert bytes(process) == psys.b(str(process))
+
+    process = sh.echo("test", _stderr=STDOUT)
+    assert str(process) == "echo test 2>&1"
+    assert bytes(process) == psys.b(str(process))
+
+    process = sh.echo("test", _stdout=DEVNULL, _stderr=DEVNULL)
+    assert str(process) == "echo test > /dev/null 2> /dev/null"
+    assert bytes(process) == psys.b(str(process))
+
 def test_disabling_stdin_redirection(test, capfd):
     """Tests disabling stdin redirection."""
 

--- a/tests/test_shell_mode.py
+++ b/tests/test_shell_mode.py
@@ -9,6 +9,12 @@ import pytest
 import psh
 from psh import sh, STDOUT, STDERR, DEVNULL
 
+from pcore import PY3
+if PY3:
+    chr = chr
+else:
+    chr = unichr
+
 import test
 test.init(globals())
 


### PR DESCRIPTION
Trying `__to_str` to show not only command args, but in addition the custom IO redirects (if other then `PIPE` or `Process` instance). It's very useful in script's 'dry-run' mode or when debugging `sysfs` commands.
Also, 8cd57e36261f92dcc7dcedc030e0c8b35ed544b6, just in-place fix for previously failed tests on `python2`. I think it should be in `pcore`.
