### PR TITLE
Don't build sphinx docs on rhel6

### DIFF
--- a/python-psh.spec
+++ b/python-psh.spec
@@ -14,7 +14,11 @@
 %endif  # with python3
 
 # Enable building of doc package
+%if 0%{?rhel} && 0%{?rhel} <= 6
+%bcond_with docs
+%else
 %bcond_without docs
+%endif
 
 # Run tests
 %bcond_without check
@@ -101,7 +105,7 @@ make PYTHON=%{__python3}
 %endif  # with python3
 
 
-%if 0%{?with_docs}
+%if 0%{with docs}
 make doc
 rm doc/_build/html/.buildinfo
 %endif  # with docs


### PR DESCRIPTION
`epel6` contains legacy `python-sphinx10` package, that provides `sphinx-*` bins with incorrect name:

```
$ rpm -qpl python-sphinx10-1.0.8-1.el6.noarch.rpm
/usr/bin/sphinx-1.0-autogen
/usr/bin/sphinx-1.0-build
/usr/bin/sphinx-1.0-quickstart
...
```

Also, `rhel6-opt` contains `python-sphinx == 0.6.6` which cause an errors on build:

```
Exception occurred:
  File "/usr/lib/python2.6/site-packages/docutils/utils.py", line 315, in assemble_option_dict
    convertor = options_spec[name]  # raises KeyError if unknown
KeyError: 'special-members'
```

So, just disable building the package docs on `rhel6` by default.
[Latest package build](https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons/build/181137/)
