### PR TITLE
Fixes for IO redirect to file

### DIFF
--- a/psh/process.py
+++ b/psh/process.py
@@ -1143,12 +1143,20 @@ class Process:
         if self.__stdout_target is STDERR:
             command += " >&2"
         elif isinstance(self.__stdout_target, File):
-            command += " > " + _arg_to_str(self.__stdout_target.path)
+            if self.__stdout_target.append:
+                command += " >> "
+            else:
+                command += " > "
+            command += _arg_to_str(self.__stdout_target.path)
 
         if self.__stderr_target is STDOUT:
             command += " 2>&1"
         elif isinstance(self.__stderr_target, File):
-            command += " 2> " + _arg_to_str(self.__stderr_target.path)
+            if self.__stderr_target.append:
+                command += " 2>> "
+            else:
+                command += " 2> "
+            command += _arg_to_str(self.__stderr_target.path)
 
         return command
 

--- a/psh/process.py
+++ b/psh/process.py
@@ -581,7 +581,10 @@ class Process:
             elif self.__stdout_target is STDERR:
                 stream.write(b" >&2")
             elif isinstance(self.__stdout_target, File):
-                stream.write(b" > ")
+                if self.__stdout_target.append:
+                    stream.write(b" >> ")
+                else:
+                    stream.write(b" > ")
                 write_arg(stream, self.__stdout_target.path)
             else:
                 raise LogicalError()
@@ -592,7 +595,10 @@ class Process:
             elif self.__stderr_target is STDOUT:
                 stream.write(b" 2>&1")
             elif isinstance(self.__stderr_target, File):
-                stream.write(b" 2> ")
+                if self.__stderr_target.append:
+                    stream.write(b" 2>> ")
+                else:
+                    stream.write(b" 2> ")
                 write_arg(stream, self.__stderr_target.path)
             else:
                 raise LogicalError()

--- a/tests/test_io_redirection.py
+++ b/tests/test_io_redirection.py
@@ -26,8 +26,16 @@ def test_command_with_redirection(test):
     assert str(process) == "echo test > /tmp/test.path"
     assert bytes(process) == psys.b(str(process))
 
+    process = sh.echo("test", _stdout=File("/tmp/test.path", append=True))
+    assert str(process) == "echo test >> /tmp/test.path"
+    assert bytes(process) == psys.b(str(process))
+
     process = sh.echo("test", _stderr=File("/tmp/test.path"))
     assert str(process) == "echo test 2> /tmp/test.path"
+    assert bytes(process) == psys.b(str(process))
+
+    process = sh.echo("test", _stderr=File("/tmp/test.path", append=True))
+    assert str(process) == "echo test 2>> /tmp/test.path"
     assert bytes(process) == psys.b(str(process))
 
     process = sh.echo("test", _stderr=STDOUT)


### PR DESCRIPTION
Fixes:
* Invalid command string when redirecting IO to file with appending
```python
>>> from psh import sh
>>> from psh import File
>>> str(sh.echo("test", _stdout=File("test.txt", append=True)))
'echo test > test.txt'
```
* Invalid IO redirection to file with appending in shell mode
```python
>>> from psh import sh
>>> from psh import File
>>> sh.sh("-c", sh.echo("test", _stdout=File("test.txt", append=True)), _shell=True, _defer=False)
<psh.process.Process instance at 0x7fa53a18ad88>
>>> sh.sh("-c", sh.echo("test", _stdout=File("test.txt", append=True)), _shell=True, _defer=False)
<psh.process.Process instance at 0x7fa53a18ae18>
>>> fd = open("test.txt")
>>> fd.read()
'test\n'
>>> sh.sh("-c", sh.echo("test", _stdout=File("test.txt", append=True)), _shell=True).command()
[u'sh', '-c', 'echo test > test.txt']
````